### PR TITLE
Support for custom ServiceFetchers

### DIFF
--- a/crates/handler/src/lib.rs
+++ b/crates/handler/src/lib.rs
@@ -1,6 +1,6 @@
 #![forbid(unsafe_code)]
 
-pub use service_route::{ServiceRoute, ServiceRouteTable};
+pub use service_route::{ServiceFetcher, ServiceRoute, ServiceRouteTable};
 pub use shared_route_table::SharedRouteTable;
 
 mod constants;

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,6 +44,7 @@ impl Config {
                     tls: service.tls,
                     query_path: service.query_path.clone(),
                     subscribe_path: service.subscribe_path.clone(),
+                    custom_fetcher: None,
                 },
             );
         }

--- a/src/k8s.rs
+++ b/src/k8s.rs
@@ -70,6 +70,7 @@ pub async fn find_graphql_services() -> Result<ServiceRouteTable> {
                         tls,
                         query_path: query_path.map(ToString::to_string),
                         subscribe_path: subscribe_path.map(ToString::to_string),
+                        custom_fetcher: None,
                     },
                 );
             }


### PR DESCRIPTION
This somewhat dirtily introduces the concept of custom service fetchers, allowing `ServiceRoute`s to specify how they fetch data from remote services using the new `ServiceFetcher` trait.
The trait is very broad in that it gives the implementer complete control over how data fetching is done: transport, protocol & even the serialization format.

E.g. pseudo-code for a gRPC implementation:
```rust
struct GRPCFetcher(GrpcClient);

#[async_trait::async_trait]
impl ServiceFetcher for BalancedFetcher {
    async fn query(
        &self,
        _service: &str,
        request: Request,
        header_map: Option<&HeaderMap>,
    ) -> AnyResult<Response> {
        let req = request.into_proto();
        let resp = self.0.unary_call(&req).await?;
        Response::from_proto(resp.body.await)
    }
}

/* ... */

route_table.insert(
    service.to_string(),
    ServiceRoute {
        addr: service_addr,
        custom_fetcher: Some(Arc::new(grpc_fetcher)),
    },
);
```

This is a temporary solution while upstream gets proper support for this kind of thing (or we contribute it, whichever comes first).

This only covers queries & mutations for now; subscriptions would require doing the same kind of thing at the websocket layer.