### PR TITLE
validation: fix custom scalar args being wrongly rejected

### DIFF
--- a/crates/planner/tests/query.txt
+++ b/crates/planner/tests/query.txt
@@ -9,6 +9,7 @@
         id username
     }
     myName
+    theirName(id: 42)
 }
 ---
 {}
@@ -16,5 +17,5 @@
 {
     "type": "fetch",
     "service": "accounts",
-    "query": "query { u1:user(id: \"1234\") { id username } me { id username } u2:user(id: \"1234\") { id username } myName }"
+    "query": "query { u1:user(id: \"1234\") { id username } me { id username } u2:user(id: \"1234\") { id username } myName theirName(id: 42) }"
 }

--- a/crates/planner/tests/test.graphql
+++ b/crates/planner/tests/test.graphql
@@ -15,8 +15,11 @@ schema
     subscription: Subscription
 }
 
+scalar CustomUserID
+
 type Query {
     myName: String! @resolve(service: "accounts")
+    theirName(id: CustomUserID): String @resolve(service: "accounts")
     me: User @resolve(service: "accounts")
     user(id: ID!): User @resolve(service: "accounts")
     topProducts: [Product!]! @resolve(service: "products")

--- a/crates/validation/src/utils.rs
+++ b/crates/validation/src/utils.rs
@@ -196,6 +196,13 @@ fn is_valid_scalar_value(type_name: &str, value: &ConstValue) -> bool {
         ("Boolean", ConstValue::Boolean(_)) => true,
         ("ID", ConstValue::String(_)) => true,
         ("ID", ConstValue::Number(n)) if n.is_i64() || n.is_u64() => true,
-        _ => false,
+        ("Int", _) => false,
+        ("Float", _) => false,
+        ("String", _) => false,
+        ("Boolean", _) => false,
+        ("ID", _) => false,
+        // Otherwise, this is a custom scalar type and we defer to its ScalarType impl to decide
+        // whether the payload is valid or not.
+        _ => true,
     }
 }


### PR DESCRIPTION
Hey there,

TL;DR: the arg validator is currently wrongly rejecting _all_ custom scalar types because of [this function](https://github.com/async-graphql/graphgate/blob/7dfa18ac5589e157e905d771fa0a8bddd17d5a48/crates/validation/src/utils.rs#L191-L201):
```rust
fn is_valid_scalar_value(type_name: &str, value: &ConstValue) -> bool {
    match (type_name, value) {
        ("Int", ConstValue::Number(n)) if n.is_i64() || n.is_u64() => true,
        ("Float", ConstValue::Number(_)) => true,
        ("String", ConstValue::String(_)) => true,
        ("Boolean", ConstValue::Boolean(_)) => true,
        ("ID", ConstValue::String(_)) => true,
        ("ID", ConstValue::Number(n)) if n.is_i64() || n.is_u64() => true,
        _ => false,
    }
}
```
which pretty much tells the arg checker that any non-native scalar isn't valid when used as an argument.

This PR does two things:
1. It extends the planner test suite to demonstrate the issue:
```
./tests/query.txt
        Index: 1
thread 'test' panicked at 'called `Result::unwrap()` on an `Err` value: Response { data: Null, errors: [ServerError { message: "Invalid value for argument \"id\", expected type \"CustomUserID\"", locations: [Pos(12:15)] }], extensions: {} }', crates/planner/tests/test.rs:41:68
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
2. It modifies the above function so that it doesn't try to validate custom scalars and instead defer that job to `ScalarType::parse` later on, making the planner test suite pass once again.
